### PR TITLE
publeaks.org is misconfigured, point to .nl

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Publeaks
 
-This projects serves as a skeleton for the informative website of [Publeaks](https://www.publeaks.org) like initatives based [GlobaLeaks](https://www.globaleaks.org).
+This projects serves as a skeleton for the informative website of [Publeaks](https://www.publeaks.nl) like initatives based [GlobaLeaks](https://www.globaleaks.org).
 
 The project is internationalized in multiple languages thanks to [Transifex](https://www.transifex.com/projects/p/publeaks/).
 - https://www.transifex.com/projects/p/publeaks/


### PR DESCRIPTION
Currently a cert for publeaks.nl is served on publeaks.org. Either fix the server config, or let the links here point to .nl.
